### PR TITLE
Fix compile error

### DIFF
--- a/MobileBackup/Package.swift
+++ b/MobileBackup/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Lakr233/AppleMobileDeviceLibrary", .upToNextMajor(from: .init(1, 0, 0))),
+        .package(url: "https://github.com/Lakr233/openssl-spm", from: "3.2.0"),
     ],
     targets: [
         .executableTarget(
@@ -18,6 +19,7 @@ let package = Package(
             dependencies: [
                 "MobileBackupEndianness",
                 "AppleMobileDeviceLibrary",
+                .product(name: "OpenSSL", package: "openssl-spm"),
             ],
             cSettings: [
                 .unsafeFlags(["-w"]),


### PR DESCRIPTION
Missing package product 'OpenSSL' (in target 'MobileBackup' from project 'MobileBackup')

Xcode 16.1 beta

<img width="1110" alt="iShot_2024-08-28_10 50 50" src="https://github.com/user-attachments/assets/dd7b7df4-8036-4ade-9715-4bc5f63c4588">
