### PR TITLE
Support Liquid Glass on macOS Tahoe

### DIFF
--- a/BBackupp.xcodeproj/project.pbxproj
+++ b/BBackupp.xcodeproj/project.pbxproj
@@ -635,7 +635,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CONFIGURATION\" = \"Release\" ]; then\n    export PATH=$PATH:/opt/homebrew/bin/\n    swiftformat . --swiftversion 5.9\nfi\n";
+			shellScript = "if [ \"$CONFIGURATION\" = \"Release\" ]; then\n    export PATH=$PATH:/opt/homebrew/bin/\n brew install swiftformat && swiftformat . --swiftversion 5.9\nfi\n";
 		};
 		50C52C492BA307E800DDA49D /* Embed MobileBackup */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/BBackupp.xcodeproj/project.pbxproj
+++ b/BBackupp.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		50E3990E2B47F3D9009D3E90 /* UnregisteredDeviceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E3990D2B47F3D9009D3E90 /* UnregisteredDeviceView.swift */; };
 		50E399102B47F3E6009D3E90 /* RegisterDeviceSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E3990F2B47F3E6009D3E90 /* RegisterDeviceSheetView.swift */; };
 		50E399122B480884009D3E90 /* RegisterStepHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E399112B480884009D3E90 /* RegisterStepHeaderView.swift */; };
+		8164C36C2E34AEE90028DA83 /* ToolbarSpacer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8164C36B2E34AEE30028DA83 /* ToolbarSpacer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -192,6 +193,7 @@
 		50E3990D2B47F3D9009D3E90 /* UnregisteredDeviceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnregisteredDeviceView.swift; sourceTree = "<group>"; };
 		50E3990F2B47F3E6009D3E90 /* RegisterDeviceSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterDeviceSheetView.swift; sourceTree = "<group>"; };
 		50E399112B480884009D3E90 /* RegisterStepHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterStepHeaderView.swift; sourceTree = "<group>"; };
+		8164C36B2E34AEE30028DA83 /* ToolbarSpacer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarSpacer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -406,6 +408,7 @@
 				505D5BF92B99BE670006884F /* InputSheetView.swift */,
 				50C60CB62BA53B9F00DA4B3D /* SectionBuilder.swift */,
 				50B990822BA5D7A10035BF05 /* BackupPlanTaskItemView.swift */,
+				8164C36B2E34AEE30028DA83 /* ToolbarSpacer.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -720,6 +723,7 @@
 				50B990872BA6068A0035BF05 /* AMDManager+Apps.swift in Sources */,
 				50B9908B2BA61BE40035BF05 /* MacAddress.swift in Sources */,
 				501A477E2BA4582100C6A431 /* ResticTask.swift in Sources */,
+				8164C36C2E34AEE90028DA83 /* ToolbarSpacer.swift in Sources */,
 				502304C62B483D2B00C8314A /* MessageBoxView.swift in Sources */,
 				50B990892BA611CE0035BF05 /* DownloadSeed.swift in Sources */,
 				506A0C972B471F0F009C77A5 /* RegisterSheetView.swift in Sources */,

--- a/BBackupp.xcodeproj/project.pbxproj
+++ b/BBackupp.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		50E399102B47F3E6009D3E90 /* RegisterDeviceSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E3990F2B47F3E6009D3E90 /* RegisterDeviceSheetView.swift */; };
 		50E399122B480884009D3E90 /* RegisterStepHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E399112B480884009D3E90 /* RegisterStepHeaderView.swift */; };
 		8164C36C2E34AEE90028DA83 /* ToolbarSpacer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8164C36B2E34AEE30028DA83 /* ToolbarSpacer.swift */; };
+		8164C36E2E34B8180028DA83 /* ToolbarBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8164C36D2E34B8170028DA83 /* ToolbarBackground.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -194,6 +195,7 @@
 		50E3990F2B47F3E6009D3E90 /* RegisterDeviceSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterDeviceSheetView.swift; sourceTree = "<group>"; };
 		50E399112B480884009D3E90 /* RegisterStepHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterStepHeaderView.swift; sourceTree = "<group>"; };
 		8164C36B2E34AEE30028DA83 /* ToolbarSpacer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarSpacer.swift; sourceTree = "<group>"; };
+		8164C36D2E34B8170028DA83 /* ToolbarBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarBackground.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -371,6 +373,7 @@
 				501A47892BA4838500C6A431 /* Alert.swift */,
 				505D5BF52B99AC6C0006884F /* SavePanel.swift */,
 				50C60CC22BA5680200DA4B3D /* DecodeSize.swift */,
+				8164C36D2E34B8170028DA83 /* ToolbarBackground.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -709,6 +712,7 @@
 				501A47882BA482B900C6A431 /* ProgressPanelView.swift in Sources */,
 				501A478C2BA4859300C6A431 /* BackupPlanView.swift in Sources */,
 				506A0C6D2B470588009C77A5 /* Result.swift in Sources */,
+				8164C36E2E34B8180028DA83 /* ToolbarBackground.swift in Sources */,
 				50770BDE2B4E7F5D0056A3AB /* DeviceView.swift in Sources */,
 				501A478F2BA487CF00C6A431 /* AppSetting.swift in Sources */,
 				501A47802BA4587400C6A431 /* BackupPlan.swift in Sources */,

--- a/BBackupp/Extension/ToolbarBackground.swift
+++ b/BBackupp/Extension/ToolbarBackground.swift
@@ -1,0 +1,18 @@
+//
+//  ToolbarBackground.swift
+//  BBackupp
+//
+//  Created by luca on 26.07.2025.
+//
+
+import SwiftUI
+
+extension View {
+    @ViewBuilder func hideToolbarBackground() -> some View {
+        if #available(macOS 15.0, *) {
+            toolbarBackgroundVisibility(.hidden, for: .automatic)
+        } else {
+            self
+        }
+    }
+}

--- a/BBackupp/Interface/Pages/App/DeviceView.swift
+++ b/BBackupp/Interface/Pages/App/DeviceView.swift
@@ -75,10 +75,7 @@ struct DeviceView: View {
                 .disabled(true)
         }
 
-        ToolbarItem {
-            Button {} label: { Image(systemName: "circle.fill").opacity(0) }
-                .disabled(true)
-        }
+        _ToolbarSpacer()
 
         ToolbarItem {
             Button {
@@ -128,10 +125,7 @@ struct DeviceView: View {
             }
         }
 
-        ToolbarItem {
-            Button {} label: { Image(systemName: "circle.fill").opacity(0) }
-                .disabled(true)
-        }
+        _ToolbarSpacer()
 
         ToolbarItem {
             Button {

--- a/BBackupp/Interface/Pages/App/WelcomeView.swift
+++ b/BBackupp/Interface/Pages/App/WelcomeView.swift
@@ -18,6 +18,7 @@ struct WelcomeView: View {
             content
         }
         .padding()
+        .hideToolbarBackground()
         .background(background.ignoresSafeArea())
         .toolbar {
             ToolbarItem {

--- a/BBackupp/Interface/Pages/Register/RegisterSheetView.swift
+++ b/BBackupp/Interface/Pages/Register/RegisterSheetView.swift
@@ -80,7 +80,7 @@ struct RegisterSheetView: View {
             Color.clear
         } else {
             ColorfulView(
-                color: .constant(ColorfulPreset.jelly.colors),
+                color: .constant(ColorfulPreset.jelly.colors.map(Color.init(_:))),
                 speed: .constant(0.5)
             )
             .opacity(0.25)

--- a/BBackupp/Interface/Pages/Register/RegisterSheetView.swift
+++ b/BBackupp/Interface/Pages/Register/RegisterSheetView.swift
@@ -71,7 +71,7 @@ struct RegisterSheetView: View {
         .frame(width: 450, height: 300)
         .background(background.ignoresSafeArea())
         .onReceive(timer) { _ in scan() }
-        .onAppear { scan() }
+        .task { scan() } // start scan before appearing for better animation result
     }
 
     @ViewBuilder

--- a/BBackupp/Interface/Views/ToolbarSpacer.swift
+++ b/BBackupp/Interface/Views/ToolbarSpacer.swift
@@ -1,0 +1,28 @@
+//
+//  ToolbarSpacer.swift
+//  BBackupp
+//
+//  Created by luca on 26.07.2025.
+//
+
+import SwiftUI
+
+struct _ToolbarSpacer: ToolbarContent {
+    var body: some ToolbarContent {
+        #if compiler(>=6.2)
+        if #available(macOS 26.0, *) {
+            ToolbarSpacer()
+        } else {
+            ToolbarItem {
+                Button {} label: { Image(systemName: "circle.fill").opacity(0) }
+                    .disabled(true)
+            }
+        }
+        #else
+        ToolbarItem {
+            Button {} label: { Image(systemName: "circle.fill").opacity(0) }
+                .disabled(true)
+        }
+        #endif
+    }
+}

--- a/MobileBackup/Scripts/compile.sh
+++ b/MobileBackup/Scripts/compile.sh
@@ -31,6 +31,7 @@ echo "[*] libimobiledevice commit: $COMMIT_HASH"
 
 sed -i '' "s/\.define(\"PACKAGE_VERSION=.*\"/\.define(\"PACKAGE_VERSION=\\\\\"$COMMIT_HASH\\\\\"\"/" ./Package.swift
 
+brew install xcbeautify
 xcodebuild -scheme MobileBackup \
     -derivedDataPath Build \
     -configuration Release \

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Visit the [Releases](https://github.com/Lakr233/BBackupp/releases) on GitHub.
 
 BBackupp v2.0 is now fully open-source. You can build your own version with the included source code. Please refer to the [License](./LICENSE) for more information.
 
+To build this project, you will need:
+- Ensure you have checked out the git submodules.
+- Confirm that [`brew`](https://brew.sh) is installed.
+    > For anything else related to compile, fix them yourself. Likely, it’s your fault :P
+
 **I am unable to provide ongoing maintenance for this code due to time constraints. Therefore I made the decision to open-source it.**
 
 **It is unlikely that I will be able to provide support or update the code in the future.**


### PR DESCRIPTION
- Use `ToolbarSpacer()` on new SDKs to achieve better appearance on macOS Tahoe
- Add `hideToolbarBackground()` helper and apply it to `WelcomeView` to remove the toolbar background on supported macOS
- Switch from `.onAppear { scan() }` to `.task { scan() }` to start scanning earlier and smooth animations.

**This PR depends on https://github.com/Lakr233/BBackupp/pull/25**